### PR TITLE
Timestamp is part of the client id

### DIFF
--- a/src/GoogleAnalyticsCookieParser.php
+++ b/src/GoogleAnalyticsCookieParser.php
@@ -17,19 +17,17 @@ class GoogleAnalyticsCookieParser
      */
     public function parse($cookieString)
     {
-        $result = explode('.', $cookieString);
+        $result = explode('.', $cookieString, 3);
 
         $count = count($result);
         if ($count == 3) {
             list($version, $depth, $clientId) = $result;
             $timestamp = null;
-        } else if ($count == 4) {
-            list($version, $depth, $clientId, $timestamp) = $result;
         } else {
             throw new InvalidArgumentException(sprintf("Problem with parsing cookie string: %s Example of a correct
                 string: GA1.2.20c7aee4-176d-4926-b6bb-db24b44d9ecb", $cookieString));
         }
 
-        return new ParsedCookie($version, $depth, $clientId, $timestamp);
+        return new ParsedCookie($version, $depth, $clientId);
     }
 }

--- a/src/GoogleAnalyticsCookieParser.php
+++ b/src/GoogleAnalyticsCookieParser.php
@@ -22,7 +22,6 @@ class GoogleAnalyticsCookieParser
         $count = count($result);
         if ($count == 3) {
             list($version, $depth, $clientId) = $result;
-            $timestamp = null;
         } else {
             throw new InvalidArgumentException(sprintf("Problem with parsing cookie string: %s Example of a correct
                 string: GA1.2.20c7aee4-176d-4926-b6bb-db24b44d9ecb", $cookieString));

--- a/src/ParsedCookie.php
+++ b/src/ParsedCookie.php
@@ -19,21 +19,16 @@ class ParsedCookie
     /** @var string */
     private $clientId;
 
-    /** @var string */
-    private $timestamp;
-
     /**
      * @param string $version
      * @param string $depth
      * @param string $clientId
-     * @param string $timestamp
      */
-    public function __construct($version, $depth, $clientId, $timestamp)
+    public function __construct($version, $depth, $clientId)
     {
         $this->version = $version;
         $this->depth = $depth;
         $this->clientId = $clientId;
-        $this->timestamp = $timestamp;
     }
 
     /**
@@ -66,22 +61,6 @@ class ParsedCookie
     public function getDepth()
     {
         return $this->depth;
-    }
-
-    /**
-     * @param string $timestamp
-     */
-    public function setTimestamp($timestamp)
-    {
-        $this->timestamp = $timestamp;
-    }
-
-    /**
-     * @return string
-     */
-    public function getTimestamp()
-    {
-        return $this->timestamp;
     }
 
     /**

--- a/tests/Tests/GoogleAnalyticsCookieParserTest.php
+++ b/tests/Tests/GoogleAnalyticsCookieParserTest.php
@@ -21,8 +21,7 @@ class GoogleAnalyticsCookieParserTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame('GA1', $result->getVersion());
         $this->assertSame('2', $result->getDepth());
-        $this->assertSame('230657868', $result->getClientId());
-        $this->assertSame('1384941727', $result->getTimestamp());
+        $this->assertSame('230657868.1384941727', $result->getClientId());
     }
 
     public function testParseWithoutTimestamp()
@@ -35,7 +34,6 @@ class GoogleAnalyticsCookieParserTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('GA1', $result->getVersion());
         $this->assertSame('2', $result->getDepth());
         $this->assertSame('20c7aee4-176d-4926-b6bb-db24b44d9ecb', $result->getClientId());
-        $this->assertSame(null, $result->getTimestamp());
     }
 
     public function testInvalidArgument()


### PR DESCRIPTION
Working on an implementation that uses the _ga client id and passing to the measurement protocol api I noticed that the timestamp is part of the client. This seems to be confirmed by a Google employee in the following thread: https://groups.google.com/forum/#!topic/google-analytics-analyticsjs/AUc1LonR-6c

This is a BC break so I tagged current state of master to 0.1.0.

@ricbra @eriwin 
